### PR TITLE
emitFile for the loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+*~

--- a/README.md
+++ b/README.md
@@ -5,9 +5,49 @@
 [Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
 
 ``` javascript
-var dimensions = require("image-size!./file.png");
-// => returns js object: i.e. { width: 400, height: 300, type: "png" }
+var image = require("image-size!./file.png");
+// => returns js object: i.e. { width: 400, height: 300, type: "png", src: "file.png" }
 ```
+
+## Options
+
+### Output filename
+
+You can use the placeholders specified here -
+
+* `[ext]` the extension of the resource
+* `[name]` the basename of the resource
+* `[path]` the path of the resource relative to the `context` query parameter or option.
+* `[hash]` the hash of `options.content` (Buffer) (by default it's the hex digest of the md5 hash)
+* `[<hashType>:hash:<digestType>:<length>]` optionally one can configure
+  * other `hashType`s, i. e. `sha1`, `md5`, `sha256`, `sha512`
+  * other `digestType`s, i. e. `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`
+  * and `length` the length in chars
+* `[N]` the N-th match obtained from matching the current file name against `options.regExp`
+
+Source: https://github.com/webpack/loader-utils#interpolatename
+
+#### `config.output.imageFilename`
+
+```js
+// webpack.config.js
+module.exports = {
+    output: {
+        imageFilename: '[name]-[hash].[ext]'
+    }
+}
+```
+
+#### query param
+
+```js
+var image = require('image-size!./file.png?name=[hash].[ext]');
+```
+
+#### `config.output.publicPath`
+
+The path/URL that gets prepended to the imageFilename -
+https://github.com/webpack/docs/wiki/configuration#outputpublicpath
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var fs = require('fs');
 var sizeOf = require('image-size');
 var loaderUtils = require('loader-utils');
 
@@ -23,7 +22,6 @@ module.exports = function(content) {
     regExp: query.regExp
   });
 
-  var resourceBuf = fs.readFileSync(this.resourcePath);
   var dimensions = sizeOf(content);
 
   dimensions.src = this.options.output.publicPath

--- a/index.js
+++ b/index.js
@@ -1,15 +1,37 @@
 var fs = require('fs');
 var sizeOf = require('image-size');
+var loaderUtils = require('loader-utils');
 
 module.exports = function(content) {
   this.cacheable && this.cacheable();
+  if(!this.emitFile) throw new Error('emitFile is required from module system');
+
   this.addDependency(this.resourcePath);
-  var callback = this.async();
-  fs.readFile(this.resourcePath, function(err, buf) {
-    if (err) {
-      return callback(err);
-    }
-    var dimensions = sizeOf(buf);
-    callback(null, "module.exports = " + JSON.stringify(dimensions));
+
+  var query = loaderUtils.parseQuery(this.query);
+  var filename = "[name].[ext]";
+
+  if ('string' === typeof query.name) {
+    filename = query.name;
+  } else if (this.options.output.imageFilename) {
+    filename = this.options.output.imageFilename
+  }
+
+  var url = loaderUtils.interpolateName(this, filename, {
+    context: query.context || this.options.context,
+    content: content,
+    regExp: query.regExp
   });
+
+  var resourceBuf = fs.readFileSync(this.resourcePath);
+  var dimensions = sizeOf(content);
+
+  dimensions.src = this.options.output.publicPath
+    ? this.options.output.publicPath + url
+    : url;
+
+  this.emitFile(url, content);
+  return 'module.exports = ' + JSON.stringify(dimensions);
 };
+
+module.exports.raw = true;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "author": "Patrick Collins @patcoll",
   "description": "image size loader module for webpack",
   "dependencies": {
-    "image-size": "^0.3.5"
+    "image-size": "^0.3.5",
+    "loader-utils": "^0.2.7"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- The image is copied to the output path and the src attribute is sent with the output.
- Removes usage of fs. File contents are already available to the loader.
- Makes the loader synchronous
